### PR TITLE
added table_status

### DIFF
--- a/migrations/20221225151645-create-table.js
+++ b/migrations/20221225151645-create-table.js
@@ -18,6 +18,10 @@ module.exports = {
         allowNull: false,
         type: Sequelize.INTEGER,
       },
+      table_status: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
       createdAt: {
         defaultValue: new Date(),
         allowNull: false,

--- a/models/table.js
+++ b/models/table.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
     {
       table_number: DataTypes.INTEGER,
       capacity: DataTypes.INTEGER,
+      table_status: DataTypes.STRING,
     },
     {
       sequelize,

--- a/seeders/20221225153204-table.js
+++ b/seeders/20221225153204-table.js
@@ -14,26 +14,32 @@ module.exports = {
         {
           table_number: 1,
           capacity: 6,
+          table_status: "available",
         },
         {
           table_number: 2,
           capacity: 6,
+          table_status: "available",
         },
         {
           table_number: 3,
           capacity: 6,
+          table_status: "available",
         },
         {
           table_number: 4,
           capacity: 6,
+          table_status: "available",
         },
         {
           table_number: 5,
           capacity: 6,
+          table_status: "available",
         },
         {
           table_number: 6,
           capacity: 6,
+          table_status: "occupied",
         },
       ],
       {}


### PR DESCRIPTION
Added table_status
When customer paid the bill, the table_status will be set to available and then clear the previous order in the table.
But the previous customer order detail will be kept in the Order Details model to use for sales summarize.